### PR TITLE
Add Equals and Hashcode to ApiErrorBase / ApiErrorWithMetadata

### DIFF
--- a/backstopper-core/build.gradle
+++ b/backstopper-core/build.gradle
@@ -1,5 +1,10 @@
 evaluationDependsOn(':')
 
+compileTestJava {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 dependencies {
     compile(
             project(":nike-internal-util"),

--- a/backstopper-core/src/main/java/com/nike/backstopper/apierror/ApiErrorBase.java
+++ b/backstopper-core/src/main/java/com/nike/backstopper/apierror/ApiErrorBase.java
@@ -1,5 +1,7 @@
 package com.nike.backstopper.apierror;
 
+import com.nike.backstopper.util.ApiErrorUtil;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -102,4 +104,15 @@ public class ApiErrorBase implements ApiError {
     public Map<String, Object> getMetadata() {
         return metadata;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        return ApiErrorUtil.isApiErrorEqual(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return ApiErrorUtil.generateApiErrorHashCode(this);
+    }
+
 }

--- a/backstopper-core/src/main/java/com/nike/backstopper/apierror/ApiErrorComparator.java
+++ b/backstopper-core/src/main/java/com/nike/backstopper/apierror/ApiErrorComparator.java
@@ -1,11 +1,19 @@
 package com.nike.backstopper.apierror;
 
+import com.nike.backstopper.util.ApiErrorUtil;
+
 import java.util.Comparator;
-import java.util.Objects;
+
+import static com.nike.backstopper.util.ApiErrorUtil.generateApiErrorHashCode;
+import static com.nike.backstopper.util.ApiErrorUtil.isApiErrorEqual;
 
 /**
- * A comparator that knows how to compare {@link ApiError} instances by {@link ApiError#getName()} first, and then by
- * {@link ApiError#getMetadata()} to allow for multiple same-named errors that have different metadata.
+ * A comparator that knows how to compare {@link ApiError} instances by {@link ApiError#getName()} first,
+ * then by {@link ApiError#getErrorCode()}, and finally by everything else by comparing hashcodes using
+ * {@link ApiErrorUtil#generateApiErrorHashCode(ApiError)}.
+ * <p>
+ * <p>Note that this means two {@link ApiError}s that are identical other than metadata will be considered
+ * different by this comparator.
  *
  * @author Nic Munroe
  */
@@ -15,7 +23,7 @@ public class ApiErrorComparator implements Comparator<ApiError> {
     @Override
     public int compare(ApiError o1, ApiError o2) {
         // Use Objects.equals to account for both being null and/or allow impls to specify custom equality logic.
-        if (Objects.equals(o1, o2)) {
+        if (isApiErrorEqual(o1, o2)) {
             return 0;
         }
 
@@ -34,15 +42,12 @@ public class ApiErrorComparator implements Comparator<ApiError> {
         if (nameComparison != 0)
             return nameComparison;
 
-        // Name is the same, so they should be the same error. We do allow same-error-but-different-metadata through
-        //      as distinct errors, so the final comparison is the metadata map.
-        boolean metadataEqual = o1.getMetadata().equals(o2.getMetadata());
+        // compare error codes after name if names are equal
+        int errorCodeComparison = o1.getErrorCode().compareTo(o2.getErrorCode());
+        if (errorCodeComparison != 0)
+            return errorCodeComparison;
 
-        if (metadataEqual)
-            return 0;
-
-        // Metadata are not equal, so we consider these separate errors. At this point we just need something
-        //      deterministic to compare that will always end up with the same result.
-        return Integer.compare(o1.hashCode(), o2.hashCode());
+        // At this point we just need something deterministic to compare that will always end up with the same result.
+        return Integer.compare(generateApiErrorHashCode(o1), generateApiErrorHashCode(o2));
     }
 }

--- a/backstopper-core/src/main/java/com/nike/backstopper/apierror/ApiErrorWithMetadata.java
+++ b/backstopper-core/src/main/java/com/nike/backstopper/apierror/ApiErrorWithMetadata.java
@@ -1,5 +1,6 @@
 package com.nike.backstopper.apierror;
 
+import com.nike.backstopper.util.ApiErrorUtil;
 import com.nike.internal.util.Pair;
 
 import java.util.Collections;
@@ -79,5 +80,15 @@ public class ApiErrorWithMetadata implements ApiError {
     @Override
     public int getHttpStatusCode() {
         return delegate.getHttpStatusCode();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return ApiErrorUtil.isApiErrorEqual(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return ApiErrorUtil.generateApiErrorHashCode(this);
     }
 }

--- a/backstopper-core/src/main/java/com/nike/backstopper/util/ApiErrorUtil.java
+++ b/backstopper-core/src/main/java/com/nike/backstopper/util/ApiErrorUtil.java
@@ -1,0 +1,36 @@
+package com.nike.backstopper.util;
+
+import com.nike.backstopper.apierror.ApiError;
+
+import java.util.Objects;
+
+/**
+ * Utility class to enable sharing code between {@link ApiError} implementations. Most Backstopper end-users
+ * won't need to use this class unless you're creating custom {@link ApiError} implementations (which is not
+ * common).
+ */
+public class ApiErrorUtil {
+
+    /**
+     * Method for generating a hashcode for the given {@link ApiError} . This can be used in implementations of
+     * {@link ApiError}.
+     */
+    public static int generateApiErrorHashCode(ApiError apiError) {
+        return Objects.hash(apiError.getName(), apiError.getErrorCode(), apiError.getMessage(), apiError.getHttpStatusCode(), apiError.getMetadata());
+    }
+
+    /**
+     * Method for checking equality of two {@link ApiError}. This can be used in implementations of {@link ApiError}
+     */
+    public static boolean isApiErrorEqual(ApiError apiError, Object o) {
+        if (apiError == o) return true;
+        if (apiError == null) return false;
+        if (o == null || !(o instanceof ApiError)) return false;
+        ApiError that = (ApiError) o;
+        return apiError.getHttpStatusCode() == that.getHttpStatusCode() &&
+                Objects.equals(apiError.getName(), that.getName()) &&
+                Objects.equals(apiError.getErrorCode(), that.getErrorCode()) &&
+                Objects.equals(apiError.getMessage(), that.getMessage()) &&
+                Objects.equals(apiError.getMetadata(), that.getMetadata());
+    }
+}

--- a/backstopper-core/src/test/java/com/nike/backstopper/apierror/ApiErrorBaseTest.java
+++ b/backstopper-core/src/test/java/com/nike/backstopper/apierror/ApiErrorBaseTest.java
@@ -2,27 +2,48 @@ package com.nike.backstopper.apierror;
 
 import com.nike.internal.util.MapBuilder;
 
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 import java.util.Map;
 import java.util.UUID;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
 
 /**
  * Tests the functionality of {@link ApiErrorBase}
  */
+@RunWith(DataProviderRunner.class)
 public class ApiErrorBaseTest {
 
-    @Test(expected = IllegalArgumentException.class)
-    public void constructorShouldThrowIllegalArgumentExceptionIfPassedNullName() {
-        new ApiErrorBase(null, 42, "some error", 400);
+    @Test
+    public void constructor_should_throw_IllegalArgumentException_null_name() {
+        // when
+        Throwable ex = catchThrowable(() -> new ApiErrorBase(null, 42, "some error", 400));
+
+        // then
+        assertThat(ex)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ApiError name cannot be null");
     }
 
     @Test
-    public void mirrorConstructorShouldCopyAllFields() {
+    public void constructor_should_throw_IllegalArgumentException_null_error_code() {
+        // when
+        Throwable ex = catchThrowable(() -> new ApiErrorBase(UUID.randomUUID().toString(), null, "some error", 400));
+
+        // then
+        assertThat(ex)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("ApiError errorCode cannot be null");
+    }
+
+    @Test
+    public void mirrorConstructor_should_copy_all_fields() {
+        // given
         String name = "someName";
         int errorCode = 42;
         String message = "some error";
@@ -31,16 +52,106 @@ public class ApiErrorBaseTest {
         ApiErrorBase aeb = new ApiErrorBase(name, errorCode, message, httpStatusCode, metadata);
         ApiErrorBase mirror = new ApiErrorBase(aeb);
 
-        assertThat(mirror.getName(), is(name));
-        assertThat(mirror.getErrorCode(), is(String.valueOf(errorCode)));
-        assertThat(mirror.getMessage(), is(message));
-        assertThat(mirror.getHttpStatusCode(), is(httpStatusCode));
-        assertThat(mirror.getMetadata(), is(metadata));
+        // then
+        assertThat(mirror.getName()).isEqualTo(name);
+        assertThat(mirror.getErrorCode()).isEqualTo(String.valueOf(errorCode));
+        assertThat(mirror.getMessage()).isEqualTo(message);
+        assertThat(mirror.getHttpStatusCode()).isEqualTo(httpStatusCode);
+        assertThat(mirror.getMetadata()).isEqualTo(metadata);
+        assertThat(aeb).isEqualTo(mirror);
     }
 
     @Test
-    public void getMetadataNeverReturnsNull() {
-        ApiErrorBase aeb = new ApiErrorBase("someName", 42, "some error", 400, null);
-        assertThat(aeb.getMetadata(), notNullValue());
+    public void noMetadataStringErrorCodeConstructor_creates_as_expected() {
+        // given
+        String name = "someName";
+        String errorCode = "42";
+        String message = "some error";
+        int httpStatusCode = 400;
+
+        ApiErrorBase aeb = new ApiErrorBase(name, errorCode, message, httpStatusCode);
+
+        // then
+        assertThat(aeb.getName()).isEqualTo(name);
+        assertThat(aeb.getErrorCode()).isEqualTo(String.valueOf(errorCode));
+        assertThat(aeb.getMessage()).isEqualTo(message);
+        assertThat(aeb.getHttpStatusCode()).isEqualTo(httpStatusCode);
     }
+
+    @Test
+    public void getMetadata_never_returns_null() {
+        // given
+        ApiErrorBase aeb = new ApiErrorBase("someName", 42, "some error", 400, null);
+
+        // then
+        assertThat(aeb.getMetadata()).isNotNull();
+    }
+
+    @Test
+    public void hashcode_is_as_expected() {
+        // given
+        ApiErrorBase error = new ApiErrorBase("name", 42, "errorMessage", 400);
+        ApiErrorBase error2 = new ApiErrorBase("name", 42, "errorMessage", 400);
+
+        // then
+        assertThat(error).isEqualTo(error2);
+        assertThat(error.hashCode()).isEqualTo(error.hashCode());
+        assertThat(error.hashCode()).isEqualTo(error2.hashCode());
+    }
+
+    @Test
+    public void equals_same_object_is_true() {
+        // given
+        ApiErrorBase error = new ApiErrorBase("name", 42, "errorMessage", 400);
+
+        // then
+        assertThat(error.equals(error)).isTrue();
+    }
+
+    @Test
+    @DataProvider(value = {
+            "true",
+            "false"
+    })
+    public void equals_null_or_other_class_is_false(boolean useNull) {
+        // given
+        ApiErrorBase error = new ApiErrorBase("name", 42, "errorMessage", 400);
+
+        String otherClass = useNull? null : "";
+
+        // then
+        assertThat(error.equals(otherClass)).isFalse();
+    }
+
+    @Test
+    @DataProvider(value = {
+            "true  | false | false | false | false | false ",
+            "false | false | false | false | false | true  ",
+            "false | true  | false | false | false | false ",
+            "false | false | true  | false | false | false ",
+            "false | false | false | true  | false | false ",
+            "false | false | false | false | true  | false ",
+    }, splitBy = "\\|")
+    public void equals_returns_expected_result(boolean changeName, boolean changeErrorCode, boolean changeErrorMessage, boolean changeHttpStatusCode, boolean changeMetadata, boolean isEqual) {
+        // given
+        String name = "someName";
+        int errorCode = 42;
+        String message = "some error";
+        int httpStatusCode = 400;
+        Map<String, Object> metadata = MapBuilder.<String, Object>builder().put("foo", UUID.randomUUID().toString()).build();
+        Map<String, Object> metadata2 = MapBuilder.<String, Object>builder().put("foo", UUID.randomUUID().toString()).build();
+
+        ApiErrorBase aeb = new ApiErrorBase(name, errorCode, message, httpStatusCode, metadata);
+
+        ApiErrorBase aeb2 = new ApiErrorBase(
+                changeName? "name2" : name ,
+                changeErrorCode? 43 : errorCode,
+                changeErrorMessage? "message2" : message,
+                changeHttpStatusCode? 500 : httpStatusCode,
+                changeMetadata? metadata2 : metadata);
+
+        // then
+        assertThat(aeb.equals(aeb2)).isEqualTo(isEqual);
+    }
+
 }

--- a/backstopper-core/src/test/java/com/nike/backstopper/apierror/ApiErrorComparatorTest.java
+++ b/backstopper-core/src/test/java/com/nike/backstopper/apierror/ApiErrorComparatorTest.java
@@ -12,6 +12,9 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 /**
  * Tests the functionality of {@link com.nike.backstopper.apierror.ApiErrorComparator}
@@ -53,6 +56,29 @@ public class ApiErrorComparatorTest {
         doReturn(mockApiError2Name).when(mockApiError2).getName();
 
         assertThat(comparator.compare(mockApiError1, mockApiError2)).isEqualTo(mockApiError1Name.compareTo(mockApiError2Name));
+    }
+
+    @Test
+    public void should_use_error_code_comparison_when_args_are_valid() {
+        ApiError mockApiError1 = mock(ApiError.class);
+        ApiError mockApiError2 = mock(ApiError.class);
+
+        String name = UUID.randomUUID().toString();
+        doReturn(name).when(mockApiError1).getName();
+        doReturn(name).when(mockApiError2).getName();
+
+        String errorCode1 = UUID.randomUUID().toString();
+        String errorCode2 = UUID.randomUUID().toString();
+        doReturn(errorCode1).when(mockApiError1).getErrorCode();
+        doReturn(errorCode2).when(mockApiError2).getErrorCode();
+
+        assertThat(comparator.compare(mockApiError1, mockApiError2)).isEqualTo(errorCode1.compareTo(errorCode2));
+
+        // 2 times, once in .equals and another inside the comparator
+        verify(mockApiError1, times(2)).getErrorCode();
+        verify(mockApiError1, times(2)).getName();
+        verify(mockApiError2, times(2)).getErrorCode();
+        verify(mockApiError2, times(2)).getName();
     }
 
     @Test

--- a/backstopper-core/src/test/java/com/nike/backstopper/util/ApiErrorUtilTest.java
+++ b/backstopper-core/src/test/java/com/nike/backstopper/util/ApiErrorUtilTest.java
@@ -1,0 +1,107 @@
+package com.nike.backstopper.util;
+
+import com.nike.backstopper.apierror.ApiErrorBase;
+import com.nike.internal.util.MapBuilder;
+import com.tngtech.java.junit.dataprovider.DataProvider;
+import com.tngtech.java.junit.dataprovider.DataProviderRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+import static com.nike.backstopper.util.ApiErrorUtil.isApiErrorEqual;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(DataProviderRunner.class)
+public class ApiErrorUtilTest {
+
+    @Test
+    public void constructor_code_coverage() {
+        // given
+        ApiErrorUtil util = new ApiErrorUtil();
+
+        // then
+        assertThat(util).isNotNull();
+    }
+
+    @Test
+    public void generate_api_error_hashcode_generates_expected_hashcodes() {
+        // given
+        Map<String, Object> metadata = MapBuilder.<String, Object>builder().put("foo", UUID.randomUUID().toString()).build();
+        ApiErrorBase apiErrorBase = new ApiErrorBase("name", 42, "errorMessag", 400, metadata);
+        ApiErrorBase apiErrorBaseCopy = new ApiErrorBase("name", 42, "errorMessag", 400, metadata);
+
+        // then
+        assertThat(ApiErrorUtil.generateApiErrorHashCode(apiErrorBase))
+                .isEqualTo(Objects.hash(
+                        apiErrorBase.getName(),
+                        apiErrorBase.getErrorCode(),
+                        apiErrorBase.getMessage(),
+                        apiErrorBase.getHttpStatusCode(),
+                        apiErrorBase.getMetadata())
+                );
+
+        assertThat(apiErrorBase).isEqualTo(apiErrorBaseCopy);
+        assertThat(ApiErrorUtil.generateApiErrorHashCode(apiErrorBase))
+                .isEqualTo(ApiErrorUtil.generateApiErrorHashCode(apiErrorBaseCopy));
+    }
+
+    @Test
+    public void equals_same_object_is_true() {
+        // given
+        ApiErrorBase apiError = new ApiErrorBase("name", 42, "errorMessage", 400);
+
+        // then
+        assertThat(isApiErrorEqual(apiError, apiError)).isTrue();
+    }
+
+    @Test
+    @DataProvider(value = {
+            "false | true  | false",
+            "false | false | false",
+            "true  | false | false",
+            "true  | true  | true"
+    }, splitBy = "\\|")
+    public void equals_null_other_class(boolean firstClassNull, boolean secondClassNull, boolean expectedValue) {
+        // given
+        ApiErrorBase apiError = new ApiErrorBase("name", 42, "errorMessage", 400);
+
+        String otherClass = secondClassNull ? null : "";
+
+        // then
+        assertThat(isApiErrorEqual(firstClassNull ? null : apiError, otherClass)).isEqualTo(expectedValue);
+    }
+
+    @Test
+    @DataProvider(value = {
+            "true  | false | false | false | false | false ",
+            "false | false | false | false | false | true  ",
+            "false | true  | false | false | false | false ",
+            "false | false | true  | false | false | false ",
+            "false | false | false | true  | false | false ",
+            "false | false | false | false | true  | false ",
+    }, splitBy = "\\|")
+    public void equals_returns_expected_result(boolean changeName, boolean changeErrorCode, boolean changeErrorMessage, boolean changeHttpStatusCode, boolean changeMetadata, boolean isEqual) {
+        // given
+        String name = "someName";
+        int errorCode = 42;
+        String message = "some error";
+        int httpStatusCode = 400;
+        Map<String, Object> metadata = MapBuilder.<String, Object>builder().put("foo", UUID.randomUUID().toString()).build();
+        Map<String, Object> metadata2 = MapBuilder.<String, Object>builder().put("foo", UUID.randomUUID().toString()).build();
+
+        ApiErrorBase aeb = new ApiErrorBase(name, errorCode, message, httpStatusCode, metadata);
+
+        ApiErrorBase aeb2 = new ApiErrorBase(
+                changeName ? "name2" : name,
+                changeErrorCode ? 43 : errorCode,
+                changeErrorMessage ? "message2" : message,
+                changeHttpStatusCode ? 500 : httpStatusCode,
+                changeMetadata ? metadata2 : metadata);
+
+        // then
+        assertThat(isApiErrorEqual(aeb, aeb2)).isEqualTo(isEqual);
+    }
+}


### PR DESCRIPTION
Add equals and hashcode methods to ApiErrorBase and ApiErrorWithMetadata. Modify ApiErrorComparator to use new comparison and sort by ErrorCode after Name.