### PR TITLE
Set SpringApiExceptionHandler's order to be highest plus 1

### DIFF
--- a/backstopper-spring-web-mvc/src/main/java/com/nike/backstopper/handler/spring/SpringApiExceptionHandler.java
+++ b/backstopper-spring-web-mvc/src/main/java/com/nike/backstopper/handler/spring/SpringApiExceptionHandler.java
@@ -43,15 +43,16 @@ public class SpringApiExceptionHandler extends ApiExceptionHandlerServletApiBase
 
     /**
      * The sort order for where this handler goes in the spring exception handler chain. We default to {@link
-     * Ordered#HIGHEST_PRECEDENCE} so that this is tried first before any other handlers.
+     * Ordered#HIGHEST_PRECEDENCE} plus one, so that this is tried first before any other handlers but after
+     * Springboot's {@code DefaultErrorAttributes} (or any other similar handler that adds some error context info to
+     * the servlet request attributes but doesn't actually handle the error).
      */
-    private int order = Ordered.HIGHEST_PRECEDENCE;
+    private int order = Ordered.HIGHEST_PRECEDENCE + 1;
 
     @SuppressWarnings("WeakerAccess")
     protected final SpringApiExceptionHandlerUtils springUtils;
 
     @Inject
-    @SuppressWarnings("WeakerAccess")
     public SpringApiExceptionHandler(ProjectApiErrors projectApiErrors,
                                      ApiExceptionHandlerListenerList apiExceptionHandlerListeners,
                                      ApiExceptionHandlerUtils generalUtils,
@@ -102,7 +103,7 @@ public class SpringApiExceptionHandler extends ApiExceptionHandlerServletApiBase
     /**
      * See the javadocs for {@link #order} for info on what this is for.
      */
-    @SuppressWarnings({"unused", "WeakerAccess"})
+    @SuppressWarnings({"unused"})
     public void setOrder(int order) {
         this.order = order;
     }

--- a/backstopper-spring-web-mvc/src/test/java/com/nike/backstopper/handler/spring/SpringApiExceptionHandlerTest.java
+++ b/backstopper-spring-web-mvc/src/test/java/com/nike/backstopper/handler/spring/SpringApiExceptionHandlerTest.java
@@ -8,6 +8,7 @@ import com.nike.backstopper.handler.spring.listener.ApiExceptionHandlerListenerL
 
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.core.Ordered;
 import org.springframework.web.servlet.ModelAndView;
 
 import java.util.Collections;
@@ -84,6 +85,20 @@ public class SpringApiExceptionHandlerTest {
 
         // then
         assertThat(handlerSpy.getOrder()).isEqualTo(newOrder);
+    }
+
+    @Test
+    public void default_order_is_highest_precedence_plus_one() {
+        // given
+        SpringApiExceptionHandler impl = new SpringApiExceptionHandler(
+            projectApiErrorsMock, listenerList, generalUtils, springUtils
+        );
+
+        // when
+        int defaultOrder = impl.getOrder();
+
+        // then
+        assertThat(defaultOrder).isEqualTo(Ordered.HIGHEST_PRECEDENCE + 1);
     }
 
 }


### PR DESCRIPTION
This will allow for DefaultErrorAttributes or similar handlers to do their work.