### PR TITLE
Feature/spring oneoff errors

### DIFF
--- a/backstopper-core/src/test/java/com/nike/backstopper/handler/listener/impl/ListenerTestBase.java
+++ b/backstopper-core/src/test/java/com/nike/backstopper/handler/listener/impl/ListenerTestBase.java
@@ -5,9 +5,7 @@ import com.nike.backstopper.handler.listener.ApiExceptionHandlerListenerResult;
 
 import java.util.Collection;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertTrue;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Base class for the test classes testing the various {@link com.nike.backstopper.handler.listener.ApiExceptionHandlerListener} implementations.
@@ -19,14 +17,11 @@ public abstract class ListenerTestBase {
 
     protected void validateResponse(ApiExceptionHandlerListenerResult result, boolean expectedShouldHandle, Collection<? extends ApiError> expectedErrors) {
         if (!expectedShouldHandle) {
-            assertThat(result.shouldHandleResponse, is(false));
+            assertThat(result.shouldHandleResponse).isFalse();
             return;
         }
 
-        assertThat(result.errors.size(), is(expectedErrors.size()));
-        for(ApiError error : expectedErrors) {
-            assertTrue(result.errors.contains(error));
-        }
+        assertThat(result.errors).containsExactlyInAnyOrderElementsOf(expectedErrors);
     }
 
 }

--- a/backstopper-custom-validators/build.gradle
+++ b/backstopper-custom-validators/build.gradle
@@ -1,5 +1,10 @@
 evaluationDependsOn(':')
 
+compileTestJava {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 dependencies {
     compile(
             "org.slf4j:slf4j-api:$slf4jVersion",

--- a/backstopper-jackson/build.gradle
+++ b/backstopper-jackson/build.gradle
@@ -1,5 +1,10 @@
 evaluationDependsOn(':')
 
+compileTestJava {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 dependencies {
     compile(
             project(":backstopper-core"),

--- a/backstopper-jersey1/build.gradle
+++ b/backstopper-jersey1/build.gradle
@@ -1,5 +1,10 @@
 evaluationDependsOn(':')
 
+compileTestJava {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 dependencies {
     compile(
             project(":backstopper-servlet-api"),

--- a/backstopper-jersey2/build.gradle
+++ b/backstopper-jersey2/build.gradle
@@ -1,5 +1,10 @@
 evaluationDependsOn(':')
 
+compileTestJava {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 dependencies {
     compile(
             project(":backstopper-jaxrs"),

--- a/backstopper-reusable-tests/build.gradle
+++ b/backstopper-reusable-tests/build.gradle
@@ -1,5 +1,10 @@
 evaluationDependsOn(':')
 
+compileTestJava {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 dependencies {
     compile(
             project(":backstopper-core"),

--- a/backstopper-servlet-api/build.gradle
+++ b/backstopper-servlet-api/build.gradle
@@ -1,5 +1,10 @@
 evaluationDependsOn(':')
 
+compileTestJava {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 dependencies {
     compile(
             project(":backstopper-core"),

--- a/backstopper-spring-web-mvc/build.gradle
+++ b/backstopper-spring-web-mvc/build.gradle
@@ -5,6 +5,10 @@ compileTestJava {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
+ext {
+    springSecurityVersion = '4.2.13.RELEASE'
+}
+
 dependencies {
     compile(
             project(":backstopper-servlet-api"),
@@ -21,6 +25,7 @@ dependencies {
             "com.tngtech.java:junit-dataprovider:$junitDataproviderVersion",
             "org.hamcrest:hamcrest-all:$hamcrestVersion",
             "org.springframework:spring-test:$springVersion",
-            "org.hibernate:hibernate-validator:$hibernateValidatorVersion"
+            "org.hibernate:hibernate-validator:$hibernateValidatorVersion",
+            "org.springframework.security:spring-security-core:$springSecurityVersion",
     )
 }

--- a/backstopper-spring-web-mvc/build.gradle
+++ b/backstopper-spring-web-mvc/build.gradle
@@ -1,5 +1,10 @@
 evaluationDependsOn(':')
 
+compileTestJava {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 dependencies {
     compile(
             project(":backstopper-servlet-api"),

--- a/backstopper-spring-web-mvc/src/main/java/com/nike/backstopper/handler/spring/listener/impl/OneOffSpringFrameworkExceptionHandlerListener.java
+++ b/backstopper-spring-web-mvc/src/main/java/com/nike/backstopper/handler/spring/listener/impl/OneOffSpringFrameworkExceptionHandlerListener.java
@@ -11,21 +11,26 @@ import com.nike.internal.util.Pair;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
 
+import org.springframework.beans.ConversionNotSupportedException;
 import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.converter.HttpMessageConversionException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.method.annotation.MethodArgumentConversionNotSupportedException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -68,17 +73,29 @@ public class OneOffSpringFrameworkExceptionHandlerListener implements ApiExcepti
         this.utils = utils;
     }
 
+    // NOTE: If you're comparing the exception handling done in this method with Spring's
+    //      DefaultHandlerExceptionResolver and/or ResponseEntityExceptionHandler to verify completeness, keep in
+    //      mind that MethodArgumentNotValidException and BindException are handled by
+    //      ConventionBasedSpringValidationErrorToApiErrorHandlerListener - they should not be handled here.
     @Override
     public ApiExceptionHandlerListenerResult shouldHandleException(Throwable ex) {
         SortedApiErrorSet handledErrors = null;
         List<Pair<String, String>> extraDetailsForLogging = new ArrayList<>();
 
-        if (ex instanceof NoHandlerFoundException) {
+        String exClassname = (ex == null) ? null : ex.getClass().getName();
+
+        if (
+            ex instanceof NoHandlerFoundException
+            // NoSuchRequestHandlingMethodException is a deprecated Spring 4.x exception that doesn't appear in
+            //      Spring 5 but should be translated to a 404.
+            || Objects.equals(exClassname, "org.springframework.web.servlet.mvc.multiaction.NoSuchRequestHandlingMethodException")
+        ) {
             handledErrors = singletonSortedSetOf(projectApiErrors.getNotFoundApiError());
         }
 
         if (ex instanceof TypeMismatchException) {
             TypeMismatchException tme = (TypeMismatchException) ex;
+            // The metadata will only be used if it's a 400 error.
             Map<String, Object> metadata = new LinkedHashMap<>();
 
             utils.addBaseExceptionMessageToExtraDetailsForLogging(ex, extraDetailsForLogging);
@@ -99,33 +116,80 @@ public class OneOffSpringFrameworkExceptionHandlerListener implements ApiExcepti
             if (requiredTypeNoInfoLeak != null) {
                 metadata.put("required_type", requiredTypeNoInfoLeak);
             }
-            handledErrors = singletonSortedSetOf(
-                new ApiErrorWithMetadata(projectApiErrors.getTypeConversionApiError(), metadata)
-            );
+
+            // ConversionNotSupportedException is a special case of TypeMismatchException that should be treated as
+            //      a 500 internal service error. See Spring's DefaultHandlerExceptionResolver and/or
+            //      ResponseEntityExceptionHandler for verification.
+            if (ex instanceof ConversionNotSupportedException) {
+                // We can add even more context log details if it's a MethodArgumentConversionNotSupportedException.
+                if (ex instanceof MethodArgumentConversionNotSupportedException) {
+                    MethodArgumentConversionNotSupportedException macnsEx = (MethodArgumentConversionNotSupportedException)ex;
+                    extraDetailsForLogging.add(Pair.of("method_arg_name", macnsEx.getName()));
+                    extraDetailsForLogging.add(Pair.of("method_arg_target_param", macnsEx.getParameter().toString()));
+                }
+
+                handledErrors = singletonSortedSetOf(projectApiErrors.getGenericServiceError());
+            }
+            else {
+                // All other TypeMismatchExceptions should be treated as a 400, and we can/should include the metadata.
+
+                // We can add even more context log details if it's a MethodArgumentTypeMismatchException.
+                if (ex instanceof MethodArgumentTypeMismatchException) {
+                    MethodArgumentTypeMismatchException matmEx = (MethodArgumentTypeMismatchException)ex;
+                    extraDetailsForLogging.add(Pair.of("method_arg_name", matmEx.getName()));
+                    extraDetailsForLogging.add(Pair.of("method_arg_target_param", matmEx.getParameter().toString()));
+                }
+                
+                handledErrors = singletonSortedSetOf(
+                    new ApiErrorWithMetadata(projectApiErrors.getTypeConversionApiError(), metadata)
+                );
+            }
         }
 
         if (ex instanceof ServletRequestBindingException) {
             // Malformed requests can be difficult to track down - add the exception's message to our logging details
             utils.addBaseExceptionMessageToExtraDetailsForLogging(ex, extraDetailsForLogging);
-            handledErrors = singletonSortedSetOf(projectApiErrors.getMalformedRequestApiError());
+
+            ApiError errorToUse = projectApiErrors.getMalformedRequestApiError();
+
+            // Add some extra context metadata if it's a MissingServletRequestParameterException.
+            if (ex instanceof MissingServletRequestParameterException) {
+                MissingServletRequestParameterException detailsEx = (MissingServletRequestParameterException)ex;
+                errorToUse = new ApiErrorWithMetadata(
+                    errorToUse,
+                    Pair.of("missing_param_name", (Object)detailsEx.getParameterName()),
+                    Pair.of("missing_param_type", (Object)detailsEx.getParameterType())
+                );
+            }
+
+            handledErrors = singletonSortedSetOf(errorToUse);
         }
 
         if (ex instanceof HttpMessageConversionException) {
             // Malformed requests can be difficult to track down - add the exception's message to our logging details
             utils.addBaseExceptionMessageToExtraDetailsForLogging(ex, extraDetailsForLogging);
 
-            if (isMissingExpectedContentCase((HttpMessageConversionException) ex)) {
-                handledErrors = singletonSortedSetOf(projectApiErrors.getMissingExpectedContentApiError());
+            // HttpMessageNotWritableException is a special case of HttpMessageConversionException that should be
+            //      treated as a 500 internal service error. See Spring's DefaultHandlerExceptionResolver and/or
+            //      ResponseEntityExceptionHandler for verification.
+            if (ex instanceof HttpMessageNotWritableException) {
+                handledErrors = singletonSortedSetOf(projectApiErrors.getGenericServiceError());
             }
             else {
-                // NOTE: If this was a HttpMessageNotReadableException with a cause of
-                //          com.fasterxml.jackson.databind.exc.InvalidFormatException then we *could* theoretically map
-                //          to projectApiErrors.getTypeConversionApiError(). If we ever decide to implement this, then
-                //          InvalidFormatException does contain reference to the field that failed to convert - we can
-                //          get to it via getPath(), iterating over each path object, and building the full path by
-                //          concatenating them with '.'. For now we'll just turn all errors in this category into
-                //          projectApiErrors.getMalformedRequestApiError().
-                handledErrors = singletonSortedSetOf(projectApiErrors.getMalformedRequestApiError());
+                // All other HttpMessageConversionException should be treated as a 400.
+                if (isMissingExpectedContentCase((HttpMessageConversionException) ex)) {
+                    handledErrors = singletonSortedSetOf(projectApiErrors.getMissingExpectedContentApiError());
+                }
+                else {
+                    // NOTE: If this was a HttpMessageNotReadableException with a cause of
+                    //          com.fasterxml.jackson.databind.exc.InvalidFormatException then we *could* theoretically map
+                    //          to projectApiErrors.getTypeConversionApiError(). If we ever decide to implement this, then
+                    //          InvalidFormatException does contain reference to the field that failed to convert - we can
+                    //          get to it via getPath(), iterating over each path object, and building the full path by
+                    //          concatenating them with '.'. For now we'll just turn all errors in this category into
+                    //          projectApiErrors.getMalformedRequestApiError().
+                    handledErrors = singletonSortedSetOf(projectApiErrors.getMalformedRequestApiError());
+                }
             }
         }
 
@@ -139,6 +203,22 @@ public class OneOffSpringFrameworkExceptionHandlerListener implements ApiExcepti
 
         if (ex instanceof HttpRequestMethodNotSupportedException) {
             handledErrors = singletonSortedSetOf(projectApiErrors.getMethodNotAllowedApiError());
+        }
+
+        if (ex instanceof MissingServletRequestPartException) {
+            MissingServletRequestPartException detailsEx = (MissingServletRequestPartException)ex;
+            handledErrors = singletonSortedSetOf(
+                new ApiErrorWithMetadata(
+                    projectApiErrors.getMalformedRequestApiError(),
+                    Pair.of("missing_required_part", (Object)detailsEx.getRequestPartName())
+                )
+            );
+        }
+
+        // AsyncRequestTimeoutException didn't show up until more recent versions of Spring, so we'll check for it
+        //      by classname to prevent unnecessarily breaking existing Backstopper users on older versions of Spring.
+        if (Objects.equals(exClassname, "org.springframework.web.context.request.async.AsyncRequestTimeoutException")) {
+            handledErrors = singletonSortedSetOf(projectApiErrors.getTemporaryServiceProblemApiError());
         }
 
         if (handledErrors != null) {
@@ -159,6 +239,7 @@ public class OneOffSpringFrameworkExceptionHandlerListener implements ApiExcepti
 
             // An older/more unusual case. Unfortunately there's a lot of manual digging that we have to do to determine
             //      that we've reached this case.
+            //noinspection RedundantIfStatement
             if (ex.getCause() != null && ex.getCause() instanceof JsonMappingException
                 && ex.getCause().getMessage() != null && ex.getCause().getMessage()
                                                            .contains("No content to map due to end-of-input")) {

--- a/backstopper-spring-web-mvc/src/main/java/com/nike/backstopper/handler/spring/listener/impl/OneOffSpringFrameworkExceptionHandlerListener.java
+++ b/backstopper-spring-web-mvc/src/main/java/com/nike/backstopper/handler/spring/listener/impl/OneOffSpringFrameworkExceptionHandlerListener.java
@@ -2,7 +2,6 @@ package com.nike.backstopper.handler.spring.listener.impl;
 
 import com.nike.backstopper.apierror.ApiError;
 import com.nike.backstopper.apierror.ApiErrorWithMetadata;
-import com.nike.backstopper.apierror.SortedApiErrorSet;
 import com.nike.backstopper.apierror.projectspecificinfo.ProjectApiErrors;
 import com.nike.backstopper.handler.ApiExceptionHandlerUtils;
 import com.nike.backstopper.handler.listener.ApiExceptionHandlerListener;
@@ -101,7 +100,6 @@ public class OneOffSpringFrameworkExceptionHandlerListener implements ApiExcepti
     //      ConventionBasedSpringValidationErrorToApiErrorHandlerListener - they should not be handled here.
     @Override
     public ApiExceptionHandlerListenerResult shouldHandleException(Throwable ex) {
-        SortedApiErrorSet handledErrors = null;
         List<Pair<String, String>> extraDetailsForLogging = new ArrayList<>();
 
         String exClassname = (ex == null) ? null : ex.getClass().getName();
@@ -112,150 +110,120 @@ public class OneOffSpringFrameworkExceptionHandlerListener implements ApiExcepti
             //      Spring 5 but should be translated to a 404.
             || Objects.equals(exClassname, "org.springframework.web.servlet.mvc.multiaction.NoSuchRequestHandlingMethodException")
         ) {
-            handledErrors = singletonSortedSetOf(projectApiErrors.getNotFoundApiError());
+            return handleError(projectApiErrors.getNotFoundApiError(), extraDetailsForLogging);
         }
 
         if (ex instanceof TypeMismatchException) {
-            TypeMismatchException tme = (TypeMismatchException) ex;
-            // The metadata will only be used if it's a 400 error.
-            Map<String, Object> metadata = new LinkedHashMap<>();
-
-            utils.addBaseExceptionMessageToExtraDetailsForLogging(ex, extraDetailsForLogging);
-
-            String badPropName = extractPropertyName(tme);
-            String badPropValue = (tme.getValue() == null) ? null : String.valueOf(tme.getValue());
-            String requiredTypeNoInfoLeak = extractRequiredTypeNoInfoLeak(tme);
-
-            extraDetailsForLogging.add(Pair.of("bad_property_name", badPropName));
-            if (badPropName != null) {
-                metadata.put("bad_property_name", badPropName);
-            }
-            extraDetailsForLogging.add(Pair.of("bad_property_value", String.valueOf(tme.getValue())));
-            if (badPropValue != null) {
-                metadata.put("bad_property_value", badPropValue);
-            }
-            extraDetailsForLogging.add(Pair.of("required_type", String.valueOf(tme.getRequiredType())));
-            if (requiredTypeNoInfoLeak != null) {
-                metadata.put("required_type", requiredTypeNoInfoLeak);
-            }
-
-            // ConversionNotSupportedException is a special case of TypeMismatchException that should be treated as
-            //      a 500 internal service error. See Spring's DefaultHandlerExceptionResolver and/or
-            //      ResponseEntityExceptionHandler for verification.
-            if (ex instanceof ConversionNotSupportedException) {
-                // We can add even more context log details if it's a MethodArgumentConversionNotSupportedException.
-                if (ex instanceof MethodArgumentConversionNotSupportedException) {
-                    MethodArgumentConversionNotSupportedException macnsEx = (MethodArgumentConversionNotSupportedException)ex;
-                    extraDetailsForLogging.add(Pair.of("method_arg_name", macnsEx.getName()));
-                    extraDetailsForLogging.add(Pair.of("method_arg_target_param", macnsEx.getParameter().toString()));
-                }
-
-                handledErrors = singletonSortedSetOf(projectApiErrors.getGenericServiceError());
-            }
-            else {
-                // All other TypeMismatchExceptions should be treated as a 400, and we can/should include the metadata.
-
-                // We can add even more context log details if it's a MethodArgumentTypeMismatchException.
-                if (ex instanceof MethodArgumentTypeMismatchException) {
-                    MethodArgumentTypeMismatchException matmEx = (MethodArgumentTypeMismatchException)ex;
-                    extraDetailsForLogging.add(Pair.of("method_arg_name", matmEx.getName()));
-                    extraDetailsForLogging.add(Pair.of("method_arg_target_param", matmEx.getParameter().toString()));
-                }
-                
-                handledErrors = singletonSortedSetOf(
-                    new ApiErrorWithMetadata(projectApiErrors.getTypeConversionApiError(), metadata)
-                );
-            }
+            return handleTypeMismatchException((TypeMismatchException)ex, extraDetailsForLogging);
         }
 
         if (ex instanceof ServletRequestBindingException) {
-            // Malformed requests can be difficult to track down - add the exception's message to our logging details
-            utils.addBaseExceptionMessageToExtraDetailsForLogging(ex, extraDetailsForLogging);
-
-            ApiError errorToUse = projectApiErrors.getMalformedRequestApiError();
-
-            // Add some extra context metadata if it's a MissingServletRequestParameterException.
-            if (ex instanceof MissingServletRequestParameterException) {
-                MissingServletRequestParameterException detailsEx = (MissingServletRequestParameterException)ex;
-                errorToUse = new ApiErrorWithMetadata(
-                    errorToUse,
-                    Pair.of("missing_param_name", (Object)detailsEx.getParameterName()),
-                    Pair.of("missing_param_type", (Object)detailsEx.getParameterType())
-                );
-            }
-
-            handledErrors = singletonSortedSetOf(errorToUse);
+            return handleServletRequestBindingException((ServletRequestBindingException)ex, extraDetailsForLogging);
         }
 
         if (ex instanceof HttpMessageConversionException) {
-            // Malformed requests can be difficult to track down - add the exception's message to our logging details
-            utils.addBaseExceptionMessageToExtraDetailsForLogging(ex, extraDetailsForLogging);
-
-            // HttpMessageNotWritableException is a special case of HttpMessageConversionException that should be
-            //      treated as a 500 internal service error. See Spring's DefaultHandlerExceptionResolver and/or
-            //      ResponseEntityExceptionHandler for verification.
-            if (ex instanceof HttpMessageNotWritableException) {
-                handledErrors = singletonSortedSetOf(projectApiErrors.getGenericServiceError());
-            }
-            else {
-                // All other HttpMessageConversionException should be treated as a 400.
-                if (isMissingExpectedContentCase((HttpMessageConversionException) ex)) {
-                    handledErrors = singletonSortedSetOf(projectApiErrors.getMissingExpectedContentApiError());
-                }
-                else {
-                    // NOTE: If this was a HttpMessageNotReadableException with a cause of
-                    //          com.fasterxml.jackson.databind.exc.InvalidFormatException then we *could* theoretically map
-                    //          to projectApiErrors.getTypeConversionApiError(). If we ever decide to implement this, then
-                    //          InvalidFormatException does contain reference to the field that failed to convert - we can
-                    //          get to it via getPath(), iterating over each path object, and building the full path by
-                    //          concatenating them with '.'. For now we'll just turn all errors in this category into
-                    //          projectApiErrors.getMalformedRequestApiError().
-                    handledErrors = singletonSortedSetOf(projectApiErrors.getMalformedRequestApiError());
-                }
-            }
+            return handleHttpMessageConversionException((HttpMessageConversionException)ex, extraDetailsForLogging);
         }
 
         if (ex instanceof HttpMediaTypeNotAcceptableException) {
-            handledErrors = singletonSortedSetOf(projectApiErrors.getNoAcceptableRepresentationApiError());
+            return handleError(projectApiErrors.getNoAcceptableRepresentationApiError(), extraDetailsForLogging);
         }
 
         if (ex instanceof HttpMediaTypeNotSupportedException) {
-            handledErrors = singletonSortedSetOf(projectApiErrors.getUnsupportedMediaTypeApiError());
+            return handleError(projectApiErrors.getUnsupportedMediaTypeApiError(), extraDetailsForLogging);
         }
 
         if (ex instanceof HttpRequestMethodNotSupportedException) {
-            handledErrors = singletonSortedSetOf(projectApiErrors.getMethodNotAllowedApiError());
+            return handleError(projectApiErrors.getMethodNotAllowedApiError(), extraDetailsForLogging);
         }
 
         if (ex instanceof MissingServletRequestPartException) {
             MissingServletRequestPartException detailsEx = (MissingServletRequestPartException)ex;
-            handledErrors = singletonSortedSetOf(
+            return handleError(
                 new ApiErrorWithMetadata(
                     projectApiErrors.getMalformedRequestApiError(),
                     Pair.of("missing_required_part", (Object)detailsEx.getRequestPartName())
-                )
+                ),
+                extraDetailsForLogging
             );
         }
 
         // AsyncRequestTimeoutException didn't show up until more recent versions of Spring, so we'll check for it
         //      by classname to prevent unnecessarily breaking existing Backstopper users on older versions of Spring.
         if (Objects.equals(exClassname, "org.springframework.web.context.request.async.AsyncRequestTimeoutException")) {
-            handledErrors = singletonSortedSetOf(projectApiErrors.getTemporaryServiceProblemApiError());
+            return handleError(projectApiErrors.getTemporaryServiceProblemApiError(), extraDetailsForLogging);
         }
 
         if (isA401UnauthorizedExceptionClassname(exClassname)) {
-            handledErrors = singletonSortedSetOf(projectApiErrors.getUnauthorizedApiError());
+            return handleError(projectApiErrors.getUnauthorizedApiError(), extraDetailsForLogging);
         }
 
         if (isA403ForibddenExceptionClassname(exClassname)) {
-            handledErrors = singletonSortedSetOf(projectApiErrors.getForbiddenApiError());
+            return handleError(projectApiErrors.getForbiddenApiError(), extraDetailsForLogging);
         }
 
-        if (handledErrors != null) {
-            return ApiExceptionHandlerListenerResult.handleResponse(handledErrors, extraDetailsForLogging);
-        }
-
+        // This exception is not handled here.
         return ApiExceptionHandlerListenerResult.ignoreResponse();
+    }
+
+    protected ApiExceptionHandlerListenerResult handleError(
+        ApiError error,
+        List<Pair<String, String>> extraDetailsForLogging
+    ) {
+        return ApiExceptionHandlerListenerResult.handleResponse(singletonSortedSetOf(error), extraDetailsForLogging);
+    }
+
+    protected ApiExceptionHandlerListenerResult handleServletRequestBindingException(
+        ServletRequestBindingException ex,
+        List<Pair<String, String>> extraDetailsForLogging
+    ) {
+        // Malformed requests can be difficult to track down - add the exception's message to our logging details
+        utils.addBaseExceptionMessageToExtraDetailsForLogging(ex, extraDetailsForLogging);
+
+        ApiError errorToUse = projectApiErrors.getMalformedRequestApiError();
+
+        // Add some extra context metadata if it's a MissingServletRequestParameterException.
+        if (ex instanceof MissingServletRequestParameterException) {
+            MissingServletRequestParameterException detailsEx = (MissingServletRequestParameterException)ex;
+            errorToUse = new ApiErrorWithMetadata(
+                errorToUse,
+                Pair.of("missing_param_name", (Object)detailsEx.getParameterName()),
+                Pair.of("missing_param_type", (Object)detailsEx.getParameterType())
+            );
+        }
+
+        return handleError(errorToUse, extraDetailsForLogging);
+    }
+
+    protected ApiExceptionHandlerListenerResult handleHttpMessageConversionException(
+        HttpMessageConversionException ex,
+        List<Pair<String, String>> extraDetailsForLogging
+    ) {
+        // Malformed requests can be difficult to track down - add the exception's message to our logging details
+        utils.addBaseExceptionMessageToExtraDetailsForLogging(ex, extraDetailsForLogging);
+
+        // HttpMessageNotWritableException is a special case of HttpMessageConversionException that should be
+        //      treated as a 500 internal service error. See Spring's DefaultHandlerExceptionResolver and/or
+        //      ResponseEntityExceptionHandler for verification.
+        if (ex instanceof HttpMessageNotWritableException) {
+            return handleError(projectApiErrors.getGenericServiceError(), extraDetailsForLogging);
+        }
+        else {
+            // All other HttpMessageConversionException should be treated as a 400.
+            if (isMissingExpectedContentCase(ex)) {
+                return handleError(projectApiErrors.getMissingExpectedContentApiError(), extraDetailsForLogging);
+            }
+            else {
+                // NOTE: If this was a HttpMessageNotReadableException with a cause of
+                //          com.fasterxml.jackson.databind.exc.InvalidFormatException then we *could* theoretically map
+                //          to projectApiErrors.getTypeConversionApiError(). If we ever decide to implement this, then
+                //          InvalidFormatException does contain reference to the field that failed to convert - we can
+                //          get to it via getPath(), iterating over each path object, and building the full path by
+                //          concatenating them with '.'. For now we'll just turn all errors in this category into
+                //          projectApiErrors.getMalformedRequestApiError().
+                return handleError(projectApiErrors.getMalformedRequestApiError(), extraDetailsForLogging);
+            }
+        }
     }
 
     protected boolean isMissingExpectedContentCase(HttpMessageConversionException ex) {
@@ -278,6 +246,62 @@ public class OneOffSpringFrameworkExceptionHandlerListener implements ApiExcepti
         }
 
         return false;
+    }
+
+    protected ApiExceptionHandlerListenerResult handleTypeMismatchException(
+        TypeMismatchException ex,
+        List<Pair<String, String>> extraDetailsForLogging
+    ) {
+        // The metadata will only be used if it's a 400 error.
+        Map<String, Object> metadata = new LinkedHashMap<>();
+
+        utils.addBaseExceptionMessageToExtraDetailsForLogging(ex, extraDetailsForLogging);
+
+        String badPropName = extractPropertyName(ex);
+        String badPropValue = (ex.getValue() == null) ? null : String.valueOf(ex.getValue());
+        String requiredTypeNoInfoLeak = extractRequiredTypeNoInfoLeak(ex);
+
+        extraDetailsForLogging.add(Pair.of("bad_property_name", badPropName));
+        if (badPropName != null) {
+            metadata.put("bad_property_name", badPropName);
+        }
+        extraDetailsForLogging.add(Pair.of("bad_property_value", String.valueOf(ex.getValue())));
+        if (badPropValue != null) {
+            metadata.put("bad_property_value", badPropValue);
+        }
+        extraDetailsForLogging.add(Pair.of("required_type", String.valueOf(ex.getRequiredType())));
+        if (requiredTypeNoInfoLeak != null) {
+            metadata.put("required_type", requiredTypeNoInfoLeak);
+        }
+
+        // ConversionNotSupportedException is a special case of TypeMismatchException that should be treated as
+        //      a 500 internal service error. See Spring's DefaultHandlerExceptionResolver and/or
+        //      ResponseEntityExceptionHandler for verification.
+        if (ex instanceof ConversionNotSupportedException) {
+            // We can add even more context log details if it's a MethodArgumentConversionNotSupportedException.
+            if (ex instanceof MethodArgumentConversionNotSupportedException) {
+                MethodArgumentConversionNotSupportedException macnsEx = (MethodArgumentConversionNotSupportedException)ex;
+                extraDetailsForLogging.add(Pair.of("method_arg_name", macnsEx.getName()));
+                extraDetailsForLogging.add(Pair.of("method_arg_target_param", macnsEx.getParameter().toString()));
+            }
+
+            return handleError(projectApiErrors.getGenericServiceError(), extraDetailsForLogging);
+        }
+        else {
+            // All other TypeMismatchExceptions should be treated as a 400, and we can/should include the metadata.
+
+            // We can add even more context log details if it's a MethodArgumentTypeMismatchException.
+            if (ex instanceof MethodArgumentTypeMismatchException) {
+                MethodArgumentTypeMismatchException matmEx = (MethodArgumentTypeMismatchException)ex;
+                extraDetailsForLogging.add(Pair.of("method_arg_name", matmEx.getName()));
+                extraDetailsForLogging.add(Pair.of("method_arg_target_param", matmEx.getParameter().toString()));
+            }
+
+            return handleError(
+                new ApiErrorWithMetadata(projectApiErrors.getTypeConversionApiError(), metadata),
+                extraDetailsForLogging
+            );
+        }
     }
 
     protected String extractPropertyName(TypeMismatchException tme) {

--- a/backstopper-spring-web-mvc/src/test/java/com/nike/backstopper/handler/spring/listener/impl/OneOffSpringFrameworkExceptionHandlerListenerTest.java
+++ b/backstopper-spring-web-mvc/src/test/java/com/nike/backstopper/handler/spring/listener/impl/OneOffSpringFrameworkExceptionHandlerListenerTest.java
@@ -1,5 +1,6 @@
 package com.nike.backstopper.handler.spring.listener.impl;
 
+import com.nike.backstopper.apierror.ApiError;
 import com.nike.backstopper.apierror.ApiErrorWithMetadata;
 import com.nike.backstopper.apierror.projectspecificinfo.ProjectApiErrors;
 import com.nike.backstopper.apierror.testutil.ProjectApiErrorsForTesting;
@@ -7,6 +8,7 @@ import com.nike.backstopper.exception.ApiException;
 import com.nike.backstopper.handler.ApiExceptionHandlerUtils;
 import com.nike.backstopper.handler.listener.ApiExceptionHandlerListenerResult;
 import com.nike.backstopper.handler.listener.impl.ListenerTestBase;
+import com.nike.internal.util.MapBuilder;
 import com.nike.internal.util.Pair;
 
 import com.fasterxml.jackson.databind.JsonMappingException;
@@ -15,26 +17,40 @@ import com.tngtech.java.junit.dataprovider.DataProviderRunner;
 import com.tngtech.java.junit.dataprovider.UseDataProvider;
 
 import org.assertj.core.api.Assertions;
-import org.assertj.core.api.ThrowableAssert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.ConversionNotSupportedException;
 import org.springframework.beans.TypeMismatchException;
+import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.converter.HttpMessageConversionException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.ServletRequestBindingException;
+import org.springframework.web.context.request.async.AsyncRequestTimeoutException;
 import org.springframework.web.method.annotation.MethodArgumentConversionNotSupportedException;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.web.servlet.mvc.multiaction.NoSuchRequestHandlingMethodException;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
@@ -60,136 +76,344 @@ public class OneOffSpringFrameworkExceptionHandlerListenerTest extends ListenerT
         OneOffSpringFrameworkExceptionHandlerListener impl = new OneOffSpringFrameworkExceptionHandlerListener(projectErrorsMock, utilsMock);
 
         // then
-        Assertions.assertThat(impl.projectApiErrors).isSameAs(projectErrorsMock);
-        Assertions.assertThat(impl.utils).isSameAs(utilsMock);
+        assertThat(impl.projectApiErrors).isSameAs(projectErrorsMock);
+        assertThat(impl.utils).isSameAs(utilsMock);
     }
 
     @Test
     public void constructor_throws_IllegalArgumentException_if_passed_null_projectApiErrors() {
         // when
-        Throwable ex = Assertions.catchThrowable(new ThrowableAssert.ThrowingCallable() {
-            @Override
-            public void call() throws Throwable {
-                new OneOffSpringFrameworkExceptionHandlerListener(null, ApiExceptionHandlerUtils.DEFAULT_IMPL);
-            }
-        });
+        Throwable ex = Assertions.catchThrowable(
+            () -> new OneOffSpringFrameworkExceptionHandlerListener(null, ApiExceptionHandlerUtils.DEFAULT_IMPL)
+        );
 
         // then
-        Assertions.assertThat(ex).isInstanceOf(IllegalArgumentException.class);
+        assertThat(ex).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
     public void constructor_throws_IllegalArgumentException_if_passed_null_utils() {
         // when
-        Throwable ex = Assertions.catchThrowable(new ThrowableAssert.ThrowingCallable() {
-            @Override
-            public void call() throws Throwable {
-                new OneOffSpringFrameworkExceptionHandlerListener(mock(ProjectApiErrors.class), null);
-            }
-        });
+        Throwable ex = Assertions.catchThrowable(
+            () -> new OneOffSpringFrameworkExceptionHandlerListener(mock(ProjectApiErrors.class), null)
+        );
 
         // then
-        Assertions.assertThat(ex).isInstanceOf(IllegalArgumentException.class);
-    }
-    
-    @Test
-    public void shouldIgnoreExceptionThatItDoesNotWantToHandle() {
-        validateResponse(listener.shouldHandleException(new ApiException(testProjectApiErrors.getGenericServiceError())), false, null);
+        assertThat(ex).isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void shouldReturnTYPE_CONVERSION_ERRORForTypeMismatchException() {
-        TypeMismatchException ex = new TypeMismatchException("blah", Integer.class);
-        ApiExceptionHandlerListenerResult result = listener.shouldHandleException(ex);
-        validateResponse(result, true, Collections.singletonList(
-            new ApiErrorWithMetadata(
-                testProjectApiErrors.getTypeConversionApiError(), Pair.of("bad_property_value", (Object)"blah"),
-                                                                  Pair.of("required_type", (Object)"int")
+    public void shouldHandleException_returns_ignoreResponse_if_passed_null_exception() {
+        // when
+        ApiExceptionHandlerListenerResult result = listener.shouldHandleException(null);
+
+        // then
+        validateResponse(result, false, null);
+    }
+
+    @Test
+    public void shouldHandleException_returns_ignoreResponse_if_passed_exception_it_does_not_want_to_handle() {
+        // when
+        ApiExceptionHandlerListenerResult result = listener.shouldHandleException(
+            new ApiException(testProjectApiErrors.getGenericServiceError())
+        );
+
+        // then
+        validateResponse(result, false, null);
+    }
+
+    @DataProvider(value = {
+        "true",
+        "false"
+    })
+    @Test
+    public void shouldReturnTYPE_CONVERSION_ERRORForTypeMismatchException(
+        boolean isMethodArgTypeMismatchEx
+    ) {
+        // given
+        Object valueObj = "notAnInteger";
+        Class<?> requiredType = Integer.class;
+        Throwable someCause = new RuntimeException("some cause");
+        String methodArgName = "fooArg";
+        MethodParameter methodParam = mock(MethodParameter.class);
+
+        TypeMismatchException ex =
+            (isMethodArgTypeMismatchEx)
+            ? new MethodArgumentTypeMismatchException(valueObj, requiredType, methodArgName, methodParam, someCause)
+            : new TypeMismatchException(valueObj, requiredType, someCause);
+
+        String expectedBadPropName = (isMethodArgTypeMismatchEx) ? methodArgName : null;
+
+        List<Pair<String, String>> expectedExtraDetailsForLogging = new ArrayList<>(
+            Arrays.asList(
+                Pair.of("exception_message", ex.getMessage()),
+                Pair.of("bad_property_name", expectedBadPropName),
+                Pair.of("bad_property_value", String.valueOf(valueObj)),
+                Pair.of("required_type", String.valueOf(requiredType))
             )
+        );
+
+        if (isMethodArgTypeMismatchEx) {
+            expectedExtraDetailsForLogging.add(Pair.of("method_arg_name", methodArgName));
+            expectedExtraDetailsForLogging.add(Pair.of("method_arg_target_param", methodParam.toString()));
+        }
+
+        Map<String, Object> expectedMetadata = MapBuilder
+            .builder("bad_property_value", valueObj)
+            .put("required_type", "int")
+            .build();
+
+        if (expectedBadPropName != null) {
+            expectedMetadata.put("bad_property_name", expectedBadPropName);
+        }
+
+        // when
+        ApiExceptionHandlerListenerResult result = listener.shouldHandleException(ex);
+
+        // then
+        validateResponse(result, true, singletonList(
+            new ApiErrorWithMetadata(testProjectApiErrors.getTypeConversionApiError(), expectedMetadata)
         ));
+        assertThat(result.extraDetailsForLogging).containsExactlyInAnyOrderElementsOf(expectedExtraDetailsForLogging);
     }
 
+    @DataProvider(value = {
+        "true",
+        "false"
+    })
     @Test
-    public void shouldReturnMALFORMED_REQUESTForMissingServletRequestParameterException() {
-        MissingServletRequestParameterException ex = new MissingServletRequestParameterException("someParam", "someParamType");
+    public void shouldHandleException_returns_GENERIC_SERVICE_ERROR_for_ConversionNotSupportedException(
+        boolean isMethodArgConversionEx
+    ) {
+        // given
+        Object valueObj = "notAnInteger";
+        Class<?> requiredType = Integer.class;
+        Throwable someCause = new RuntimeException("some cause");
+        String methodArgName = "fooArg";
+        MethodParameter methodParam = mock(MethodParameter.class);
+
+        ConversionNotSupportedException ex =
+            (isMethodArgConversionEx)
+            ? new MethodArgumentConversionNotSupportedException(valueObj, requiredType, methodArgName, methodParam, someCause)
+            : new ConversionNotSupportedException(valueObj, requiredType, someCause);
+
+        String expectedBadPropName = (isMethodArgConversionEx) ? methodArgName : null;
+
+        List<Pair<String, String>> expectedExtraDetailsForLogging = new ArrayList<>(
+            Arrays.asList(
+                Pair.of("exception_message", ex.getMessage()),
+                Pair.of("bad_property_name", expectedBadPropName),
+                Pair.of("bad_property_value", String.valueOf(valueObj)),
+                Pair.of("required_type", String.valueOf(requiredType))
+            )
+        );
+
+        if (isMethodArgConversionEx) {
+            expectedExtraDetailsForLogging.add(Pair.of("method_arg_name", methodArgName));
+            expectedExtraDetailsForLogging.add(Pair.of("method_arg_target_param", methodParam.toString()));
+        }
+
+        // when
         ApiExceptionHandlerListenerResult result = listener.shouldHandleException(ex);
-        validateResponse(result, true, Collections.singletonList(testProjectApiErrors.getMalformedRequestApiError()));
 
-        // Also should add base exception message to logging details.
-        assertThat(result.extraDetailsForLogging.size(), is(1));
-        assertThat(result.extraDetailsForLogging.get(0), is(Pair.of("exception_message", "Required someParamType parameter 'someParam' is not present")));
+        // then
+        validateResponse(result, true, singletonList(testProjectApiErrors.getGenericServiceError()));
+        assertThat(result.extraDetailsForLogging).containsExactlyInAnyOrderElementsOf(expectedExtraDetailsForLogging);
+    }
+
+    @DataProvider(value = {
+        "true",
+        "false"
+    })
+    @Test
+    public void shouldHandleException_returns_MALFORMED_REQUEST_for_ServletRequestBindingException(
+        boolean isMissingRequestParamEx
+    ) {
+        // given
+        String missingParamName = "someParam-" + UUID.randomUUID().toString();
+        String missingParamType = "someParamType-" + UUID.randomUUID().toString();
+        ServletRequestBindingException ex =
+            (isMissingRequestParamEx)
+            ? new MissingServletRequestParameterException(missingParamName, missingParamType)
+            : new ServletRequestBindingException("foo");
+
+        ApiError expectedResult = testProjectApiErrors.getMalformedRequestApiError();
+        if (isMissingRequestParamEx) {
+            expectedResult = new ApiErrorWithMetadata(
+                expectedResult,
+                Pair.of("missing_param_name", missingParamName),
+                Pair.of("missing_param_type", missingParamType)
+            );
+        }
+
+        String expectedExceptionMessage =
+            (isMissingRequestParamEx)
+            ? String.format("Required %s parameter '%s' is not present", missingParamType, missingParamName)
+            : "foo";
+
+        // when
+        ApiExceptionHandlerListenerResult result = listener.shouldHandleException(ex);
+
+        // then
+        validateResponse(result, true, singletonList(expectedResult));
+        assertThat(result.extraDetailsForLogging)
+            .containsExactly(Pair.of("exception_message", expectedExceptionMessage));
     }
 
     @Test
-    public void shouldReturnMALFORMED_REQUESTForHttpMessageConversionException() {
+    public void shouldHandleException_returns_MALFORMED_REQUEST_for_generic_HttpMessageConversionException() {
+        // given
         HttpMessageConversionException ex = new HttpMessageConversionException("foobar");
+
+        // when
         ApiExceptionHandlerListenerResult result = listener.shouldHandleException(ex);
-        validateResponse(result, true, Collections.singletonList(testProjectApiErrors.getMalformedRequestApiError()));
+
+        // then
+        validateResponse(result, true, singletonList(testProjectApiErrors.getMalformedRequestApiError()));
+        assertThat(result.extraDetailsForLogging).containsExactly(Pair.of("exception_message", ex.getMessage()));
+    }
+
+    private enum HttpMessageNotReadableExceptionScenario {
+        KNOWN_MESSAGE_FOR_MISSING_CONTENT(
+            new HttpMessageNotReadableException("Required request body is missing " + UUID.randomUUID().toString()),
+            ProjectApiErrors::getMissingExpectedContentApiError
+        ),
+        JSON_MAPPING_EXCEPTION_CAUSE_INDICATING_NO_CONTENT(
+            new HttpMessageNotReadableException("foobar", new JsonMappingException("No content to map due to end-of-input")),
+            ProjectApiErrors::getMissingExpectedContentApiError
+        ),
+        CAUSE_IS_NULL(
+            new HttpMessageNotReadableException("foobar", null),
+            ProjectApiErrors::getMalformedRequestApiError
+        ),
+        CAUSE_IS_NOT_JSON_MAPPING_EXCEPTION(
+            new HttpMessageNotReadableException("foobar", new Exception("No content to map due to end-of-input")),
+            ProjectApiErrors::getMalformedRequestApiError
+        ),
+        CAUSE_IS_JSON_MAPPING_EXCEPTION_BUT_JME_MESSAGE_IS_NULL(
+            new HttpMessageNotReadableException("foobar", mock(JsonMappingException.class)),
+            ProjectApiErrors::getMalformedRequestApiError
+        ),
+        CAUSE_IS_JSON_MAPPING_EXCEPTION_BUT_JME_MESSAGE_IS_NOT_THE_NO_CONTENT_MESSAGE(
+            new HttpMessageNotReadableException("foobar", new JsonMappingException("garbagio")),
+            ProjectApiErrors::getMalformedRequestApiError
+        );
+
+        public final HttpMessageNotReadableException ex;
+        private final Function<ProjectApiErrors, ApiError> expectedErrorExtractor;
+
+        HttpMessageNotReadableExceptionScenario(
+            HttpMessageNotReadableException ex,
+            Function<ProjectApiErrors, ApiError> expectedErrorExtractor
+        ) {
+            this.ex = ex;
+            this.expectedErrorExtractor = expectedErrorExtractor;
+        }
+
+        public ApiError getExpectedError(ProjectApiErrors pae) {
+            return expectedErrorExtractor.apply(pae);
+        }
+    }
+
+    @DataProvider
+    public static List<List<HttpMessageNotReadableExceptionScenario>> httpMessageNotReadableExceptionScenarioDataProvider() {
+        return Stream.of(HttpMessageNotReadableExceptionScenario.values())
+                     .map(Collections::singletonList)
+                     .collect(Collectors.toList());
+    }
+
+    @UseDataProvider("httpMessageNotReadableExceptionScenarioDataProvider")
+    @Test
+    public void shouldHandleException_returns_expected_error_for_HttpMessageNotReadableException(
+        HttpMessageNotReadableExceptionScenario scenario
+    ) {
+        // when
+        ApiExceptionHandlerListenerResult result = listener.shouldHandleException(scenario.ex);
+
+        // then
+        validateResponse(result, true, singletonList(scenario.getExpectedError(testProjectApiErrors)));
+        assertThat(result.extraDetailsForLogging).containsExactly(Pair.of("exception_message", scenario.ex.getMessage()));
     }
 
     @Test
-    public void shouldReturnMISSING_EXPECTED_CONTENTForHttpMessageNotReadableExceptionThatStartsWithKnownMessage() {
-        HttpMessageNotReadableException ex = new HttpMessageNotReadableException("Required request body is missing " + UUID.randomUUID().toString());
+    public void shouldHandleException_returns_GENERIC_SERVICE_ERROR_for_HttpMessageNotWritableException() {
+        // given
+        HttpMessageNotWritableException ex = new HttpMessageNotWritableException("foobar");
+
+        // when
         ApiExceptionHandlerListenerResult result = listener.shouldHandleException(ex);
-        validateResponse(result, true, Collections.singletonList(testProjectApiErrors.getMissingExpectedContentApiError()));
+
+        // then
+        validateResponse(result, true, singletonList(testProjectApiErrors.getGenericServiceError()));
+        assertThat(result.extraDetailsForLogging).containsExactly(Pair.of("exception_message", ex.getMessage()));
     }
 
     @Test
-    public void shouldReturnMISSING_EXPECTED_CONTENTForHttpMessageNotReadableExceptionWhenTheStarsAlign() {
-        HttpMessageNotReadableException ex = new HttpMessageNotReadableException("foobar", new JsonMappingException("No content to map due to end-of-input"));
-        ApiExceptionHandlerListenerResult result = listener.shouldHandleException(ex);
-        validateResponse(result, true, Collections.singletonList(testProjectApiErrors.getMissingExpectedContentApiError()));
-    }
-
-    @Test
-    public void shouldReturnMALFORMED_REQUESTForHttpMessageNotReadableExceptionWhenCauseIsNull() {
-        HttpMessageNotReadableException ex = new HttpMessageNotReadableException("foobar", null);
-        ApiExceptionHandlerListenerResult result = listener.shouldHandleException(ex);
-        validateResponse(result, true, Collections.singletonList(testProjectApiErrors.getMalformedRequestApiError()));
-    }
-
-    @Test
-    public void shouldReturnMALFORMED_REQUESTForHttpMessageNotReadableExceptionWhenCauseIsNotJsonMappingException() {
-        HttpMessageNotReadableException ex = new HttpMessageNotReadableException("foobar", new Exception("No content to map due to end-of-input"));
-        ApiExceptionHandlerListenerResult result = listener.shouldHandleException(ex);
-        validateResponse(result, true, Collections.singletonList(testProjectApiErrors.getMalformedRequestApiError()));
-    }
-
-    @Test
-    public void shouldReturnMALFORMED_REQUESTForHttpMessageNotReadableExceptionWhenCauseIsJsonMappingExceptionButMessageIsNull() {
-        JsonMappingException jme = mock(JsonMappingException.class);
-        doReturn(null).when(jme).getMessage();
-        HttpMessageNotReadableException ex = new HttpMessageNotReadableException("foobar", jme);
-        ApiExceptionHandlerListenerResult result = listener.shouldHandleException(ex);
-        validateResponse(result, true, Collections.singletonList(testProjectApiErrors.getMalformedRequestApiError()));
-    }
-
-    @Test
-    public void shouldReturnMALFORMED_REQUESTForHttpMessageNotReadableExceptionWhenCauseIsJsonMappingExceptionButMessageIsNotTheRightMessage() {
-        HttpMessageNotReadableException ex = new HttpMessageNotReadableException("foobar", new JsonMappingException("garbagio"));
-        ApiExceptionHandlerListenerResult result = listener.shouldHandleException(ex);
-        validateResponse(result, true, Collections.singletonList(testProjectApiErrors.getMalformedRequestApiError()));
-    }
-
-    @Test
-    public void shouldReturnNO_ACCEPTABLE_REPRESENTATIONForHttpMediaTypeNotAcceptableException() {
+    public void shouldHandleException_returns_NO_ACCEPTABLE_REPRESENTATION_for_HttpMediaTypeNotAcceptableException() {
+        // given
         HttpMediaTypeNotAcceptableException ex = new HttpMediaTypeNotAcceptableException("asplode");
+
+        // when
         ApiExceptionHandlerListenerResult result = listener.shouldHandleException(ex);
-        validateResponse(result, true, Collections.singletonList(testProjectApiErrors.getNoAcceptableRepresentationApiError()));
+
+        // then
+        validateResponse(result, true, singletonList(testProjectApiErrors.getNoAcceptableRepresentationApiError()));
     }
 
     @Test
-    public void shouldReturnUNSUPPORTED_MEDIA_TYPEForHttpMediaTypeNotSupportedException() {
+    public void shouldHandleException_returns_UNSUPPORTED_MEDIA_TYPE_for_HttpMediaTypeNotSupportedException() {
+        // given
         HttpMediaTypeNotSupportedException ex = new HttpMediaTypeNotSupportedException("asplode");
+
+        // when
         ApiExceptionHandlerListenerResult result = listener.shouldHandleException(ex);
-        validateResponse(result, true, Collections.singletonList(testProjectApiErrors.getUnsupportedMediaTypeApiError()));
+
+        // then
+        validateResponse(result, true, singletonList(testProjectApiErrors.getUnsupportedMediaTypeApiError()));
     }
 
     @Test
-    public void shouldReturnMETHOD_NOT_ALLOWEDForHttpRequestMethodNotSupportedException() {
+    public void shouldHandleException_returns_METHOD_NOT_ALLOWED_for_HttpRequestMethodNotSupportedException() {
+        // given
         HttpRequestMethodNotSupportedException ex = new HttpRequestMethodNotSupportedException("asplode");
+
+        // when
         ApiExceptionHandlerListenerResult result = listener.shouldHandleException(ex);
-        validateResponse(result, true, Collections.singletonList(testProjectApiErrors.getMethodNotAllowedApiError()));
+
+        // then
+        validateResponse(result, true, singletonList(testProjectApiErrors.getMethodNotAllowedApiError()));
+    }
+
+    @Test
+    public void shouldHandleException_returns_MALFORMED_REQUEST_for_MissingServletRequestPartException() {
+        // given
+        String partName = UUID.randomUUID().toString();
+        MissingServletRequestPartException ex = new MissingServletRequestPartException(partName);
+
+        ApiError expectedResult = new ApiErrorWithMetadata(
+            testProjectApiErrors.getMalformedRequestApiError(),
+            Pair.of("missing_required_part", partName)
+        );
+
+        // when
+        ApiExceptionHandlerListenerResult result = listener.shouldHandleException(ex);
+
+        // then
+        validateResponse(result, true, singletonList(expectedResult));
+    }
+
+    @Test
+    public void shouldHandleException_returns_TEMPORARY_SERVICE_PROBLEM_for_AsyncRequestTimeoutException() {
+        // given
+        AsyncRequestTimeoutException ex = new AsyncRequestTimeoutException();
+        assertThat(ex.getClass().getName())
+            .isEqualTo("org.springframework.web.context.request.async.AsyncRequestTimeoutException");
+
+        // when
+        ApiExceptionHandlerListenerResult result = listener.shouldHandleException(ex);
+
+        // then
+        validateResponse(result, true, singletonList(testProjectApiErrors.getTemporaryServiceProblemApiError()));
     }
 
     @Test
@@ -201,7 +425,21 @@ public class OneOffSpringFrameworkExceptionHandlerListenerTest extends ListenerT
         ApiExceptionHandlerListenerResult result = listener.shouldHandleException(ex);
 
         // then
-        validateResponse(result, true, Collections.singletonList(testProjectApiErrors.getNotFoundApiError()));
+        validateResponse(result, true, singletonList(testProjectApiErrors.getNotFoundApiError()));
+    }
+
+    @Test
+    public void shouldHandleException_should_return_not_found_error_when_passed_NoSuchRequestHandlingMethodException() {
+        // given
+        NoSuchRequestHandlingMethodException ex = new NoSuchRequestHandlingMethodException(
+            "/some/url", "GET", new HashMap<>()
+        );
+
+        // when
+        ApiExceptionHandlerListenerResult result = listener.shouldHandleException(ex);
+
+        // then
+        validateResponse(result, true, singletonList(testProjectApiErrors.getNotFoundApiError()));
     }
 
     @DataProvider
@@ -240,7 +478,7 @@ public class OneOffSpringFrameworkExceptionHandlerListenerTest extends ListenerT
         String result = listener.extractRequiredTypeNoInfoLeak(typeMismatchExceptionMock);
 
         // then
-        Assertions.assertThat(result).isEqualTo(expectedResult);
+        assertThat(result).isEqualTo(expectedResult);
     }
 
     @Test
@@ -254,7 +492,7 @@ public class OneOffSpringFrameworkExceptionHandlerListenerTest extends ListenerT
         String result = listener.extractPropertyName(exMock);
 
         // then
-        Assertions.assertThat(result).isEqualTo(name);
+        assertThat(result).isEqualTo(name);
     }
 
     @Test
@@ -268,7 +506,7 @@ public class OneOffSpringFrameworkExceptionHandlerListenerTest extends ListenerT
         String result = listener.extractPropertyName(exMock);
 
         // then
-        Assertions.assertThat(result).isEqualTo(name);
+        assertThat(result).isEqualTo(name);
     }
 
     @Test
@@ -280,6 +518,6 @@ public class OneOffSpringFrameworkExceptionHandlerListenerTest extends ListenerT
         String result = listener.extractPropertyName(exMock);
 
         // then
-        Assertions.assertThat(result).isNull();
+        assertThat(result).isNull();
     }
 }

--- a/backstopper-spring-web-mvc/src/test/java/org/springframework/web/context/request/async/AsyncRequestTimeoutException.java
+++ b/backstopper-spring-web-mvc/src/test/java/org/springframework/web/context/request/async/AsyncRequestTimeoutException.java
@@ -1,0 +1,11 @@
+package org.springframework.web.context.request.async;
+
+/**
+ * A copy of Spring's {@code AsyncRequestTimeoutException} from the same package. Used during testing to trigger
+ * code branches that require an exception with this fully qualified classname.
+ *
+ * @author Nic Munroe
+ */
+public class AsyncRequestTimeoutException extends RuntimeException {
+
+}

--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,7 @@ ext {
     mockitoVersion = '1.9.5'
     logbackVersion = '1.1.2'
     jacksonVersion = '2.4.2'
-    assertJVersion = '2.5.0'
+    assertJVersion = '3.12.2'
     junitDataproviderVersion = '1.10.1'
     hamcrestVersion = '1.3'
     hibernateValidatorVersion = '4.3.0.Final'

--- a/nike-internal-util/build.gradle
+++ b/nike-internal-util/build.gradle
@@ -4,6 +4,11 @@ version=nikeInternalUtilVersion
 groupId = nikeInternalUtilGroupId
 group = nikeInternalUtilGroupId
 
+compileTestJava {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 dependencies {
     testCompile(
             "junit:junit:$junitVersion",

--- a/samples/sample-jersey1/build.gradle
+++ b/samples/sample-jersey1/build.gradle
@@ -1,5 +1,8 @@
 evaluationDependsOn(':')
 
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
+
 dependencies {
     compile(
             project(":backstopper-jersey1"),

--- a/samples/sample-jersey2/build.gradle
+++ b/samples/sample-jersey2/build.gradle
@@ -1,5 +1,8 @@
 evaluationDependsOn(':')
 
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
+
 dependencies {
     compile(
             project(":backstopper-jersey2"),

--- a/samples/sample-spring-web-mvc/build.gradle
+++ b/samples/sample-spring-web-mvc/build.gradle
@@ -1,5 +1,8 @@
 evaluationDependsOn(':')
 
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
+
 dependencies {
     compile(
             project(":backstopper-spring-web-mvc"),

--- a/samples/sample-spring-web-mvc/src/test/java/com/nike/backstopper/springsample/componenttest/VerifyExpectedErrorsAreReturnedComponentTest.java
+++ b/samples/sample-spring-web-mvc/src/test/java/com/nike/backstopper/springsample/componenttest/VerifyExpectedErrorsAreReturnedComponentTest.java
@@ -10,6 +10,7 @@ import com.nike.backstopper.springsample.error.SampleProjectApiError;
 import com.nike.backstopper.springsample.model.RgbColor;
 import com.nike.backstopper.springsample.model.SampleModel;
 import com.nike.internal.util.MapBuilder;
+import com.nike.internal.util.Pair;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -379,7 +380,14 @@ public class VerifyExpectedErrorsAreReturnedComponentTest {
                 .log().all()
                 .extract();
 
-        verifyErrorReceived(response, SampleCoreApiError.MALFORMED_REQUEST);
+        verifyErrorReceived(
+            response,
+            new ApiErrorWithMetadata(
+                SampleCoreApiError.MALFORMED_REQUEST,
+                Pair.of("missing_param_type", "int"),
+                Pair.of("missing_param_name", "requiredQueryParamValue")
+            )
+        );
     }
 
     @Test


### PR DESCRIPTION
Adds coverage for missing Spring one-off errors and adjusts to match `DefaultHandlerExceptionResolver` and/or `ResponseEntityExceptionHandler` status code mappings where necessary.

Also adds support for spring security exceptions - this covers issue #35.