### PR TITLE
fix(backstopper-spring-web): add synthetic container for 403s, as Spring Security returns 403s when authorities are enforced in the configure method

### DIFF
--- a/backstopper-servlet-api/src/main/java/com/nike/backstopper/servletapi/UnhandledServletContainerErrorHelper.java
+++ b/backstopper-servlet-api/src/main/java/com/nike/backstopper/servletapi/UnhandledServletContainerErrorHelper.java
@@ -98,6 +98,20 @@ public class UnhandledServletContainerErrorHelper {
                 )
                 .build();
         }
+        // When spring security enforces scopes via  http.anyRequest().hasAnyAuthority("SCOPE_use:adminApi", "ROLE_ARMORY_ADMIN"),
+        // a 403 will be returned if principal is missing scope
+        if (errorStatusCode != null && errorStatusCode == 403) {
+            // It's a 403, but without an exception. Create a synthetic-but-generic exception to cover this
+            //      that will be mapped by backstopper to a 403.
+            return ApiException
+              .newBuilder()
+              .withApiErrors(projectApiErrors.getForbiddenApiError())
+              .withExceptionMessage("Synthetic exception for container 403.")
+              .withExtraDetailsForLogging(
+                Pair.of("synthetic_exception_for_container_403", "true")
+              )
+              .build();
+        }
         else {
             // It's not a 404. Create a synthetic-but-generic exception to cover this that will be mapped
             //      by backstopper to a 500.


### PR DESCRIPTION
I was writting some integration tests for auth and found that the following integration test

```java
  @Test
  public void test_that_the_internal_endpoints_can_not_be_called_by_any_authenticated_principal() {
    var principal = MockPrincipal
      .builder()
      .name("some-authenticated-principal")
      .envId(UUID.randomUUID().toString())
      .orgId(UUID.randomUUID().toString())
      .orgName("some-org-name")
      .build();

    var token = generateAccessToken(principal);

    given()
      .header("Accept", "application/json")
      .header("Content-Type", "application/json")
      .header("Authorization", token)
      .when()
      .get(String.format(getUriTemplate(), "/internal/i-dont-exist"))
      .then()
      .log()
      .everything()
      .statusCode(403);
  }
  ```
  
Was returning a 500

```
Transfer-Encoding: chunked
Date: Mon, 20 Dec 2021 20:42:35 GMT
Connection: close

{
    "error_id": "c5147c9d-9fa0-4ce1-ab40-c7b1773c83a6",
    "errors": [
        {
            "code": 10,
            "message": "An error occurred while fulfilling the request"
        }
    ]
}

1 expectation failed.
Expected status code <403> but was <500>.

java.lang.AssertionError: 1 expectation failed.
Expected status code <403> but was <500>.
```

caused by

```
[2021-12-20 12:42:35,745] [ERROR] ApiExceptionHandlerBase handled exception occurred: error_uid=c5147c9d-9fa0-4ce1-ab40-c7b1773c83a6, dtrace_id=a26246da886165d9, exception_class=com.nike.backstopper.exception.ApiException, returned_http_status_code=500, contributing_errors="GENERIC_SERVICE_ERROR", request_uri="/error", orig_error_request_uri="/internal/i-dont-exist", orig_forwarded_request_uri="/internal/i-dont-exist", request_method="GET", query_string="null", request_headers="authorization=REDACTED,host=localhost:46841,content-type=application/json,connection=Keep-Alive,accept-encoding=gzip,deflate,accept=application/json,user-agent=Apache-HttpClient/4.5.13 (Java/17)", synthetic_exception_for_unhandled_status_code="403", api_exception_message="Synthetic exception for unhandled container status code: 403"
com.nike.backstopper.exception.ApiException: Synthetic exception for unhandled container status code: 403
	at com.nike.backstopper.exception.ApiException$Builder.build(ApiException.java:349)
	at io.armory.cloud.enigma.error.port.UnhandledServletContainerErrorHelper.extractOrGenerateErrorForRequest(UnhandledServletContainerErrorHelper.java:124)
	at io.armory.cloud.enigma.error.port.BackstopperSpringboot2ContainerErrorController.error(BackstopperSpringboot2ContainerErrorController.java:57)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.springframework.web.method.support.InvocableHandlerMethod.doInvoke(InvocableHandlerMethod.java:205)
	at org.springframework.web.method.support.InvocableHandlerMethod.invokeForRequest(InvocableHandlerMethod.java:150)
	at org.springframework.web.servlet.mvc.method.annotation.ServletInvocableHandlerMethod.invokeAndHandle(ServletInvocableHandlerMethod.java:117)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.invokeHandlerMethod(RequestMappingHandlerAdapter.java:895)
	at org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerAdapter.handleInternal(RequestMappingHandlerAdapter.java:808)
	at org.springframework.web.servlet.mvc.method.AbstractHandlerMethodAdapter.handle(AbstractHandlerMethodAdapter.java:87)
	at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1067)
	at org.springframework.web.servlet.DispatcherServlet.doService(DispatcherServlet.java:963)
	at org.springframework.web.servlet.FrameworkServlet.processRequest(FrameworkServlet.java:1006)
	at org.springframework.web.servlet.FrameworkServlet.doGet(FrameworkServlet.java:898)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:655)
	at org.springframework.web.servlet.FrameworkServlet.service(FrameworkServlet.java:883)
	at javax.servlet.http.HttpServlet.service(HttpServlet.java:764)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:227)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
	at org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:103)
	at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:189)
	at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:162)
```

When you configure Spring Security like the following

```java
 @Override
  protected void configure(HttpSecurity http) throws Exception {
    // Enable cors
    http.cors();

    // Disable CSRF (cross site request forgery)
    http.csrf().disable();

    // No session will be created or used by spring security
    http
      .sessionManagement()
      .sessionCreationPolicy(SessionCreationPolicy.STATELESS);

    // Allow requests from the white list to be unauthenticated
    http
      .authorizeRequests()
      .antMatchers(authenticationNotRequiredWhitelist().toArray(new String[0]))
      .permitAll();

    // Force all other requests to be authenticated and from an armory admin principal or granted access to the admin api
    http
      .authorizeRequests()
      .antMatchers("/external/**")
      .authenticated()
      .anyRequest()
      .hasAnyAuthority("SCOPE_use:adminApi", "ROLE_ADMIN");

    // Add our authentication entry point
    http
      .exceptionHandling()
      .authenticationEntryPoint(requestWasNotAuthenticatedEntryPoint);

    // Add the auth filter
    http.addFilterBefore(
      armoryCloudOidcAuthenticationFilter,
      UsernamePasswordAuthenticationFilter.class
    );
  }
```

and a principal is missing one of the authorities

```
      .hasAnyAuthority("SCOPE_use:adminApi", "ROLE_ADMIN");
```

Then a 403 will be returned without throwing an error.

This PR catches that case and returns the default forbidden error instead.